### PR TITLE
Fix queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ sample:
 
 sample-clean:
 	@docker compose -f docker-compose.sample.yaml down
+
+benchmark:
+	dotnet run -c Release --project ./tests/benchmark/Farfetch.LoadShedding.BenchmarkTests/Farfetch.LoadShedding.BenchmarkTests.csproj

--- a/data/grafana/dashboards/http_loadshedding.json
+++ b/data/grafana/dashboards/http_loadshedding.json
@@ -83,6 +83,8 @@
       },
       "id": 55,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -92,9 +94,10 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "9.3.6",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": "$source",
@@ -154,6 +157,8 @@
       },
       "id": 59,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -163,9 +168,10 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "9.3.6",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": "$source",
@@ -223,10 +229,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.3.6",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": "$source",
@@ -285,10 +293,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "value"
+        "textMode": "value",
+        "wideLayout": true
       },
-      "pluginVersion": "9.3.6",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": "$source",
@@ -350,10 +360,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.3.6",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": "$source",
@@ -419,9 +431,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.3.6",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": "$source",
@@ -481,9 +495,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.3.6",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": "$source",
@@ -509,52 +525,132 @@
       },
       "id": 44,
       "panels": [],
-      "title": "Details",
+      "title": "Concurrency",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$source"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "limit"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    5,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "opacity"
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 9,
-        "w": 6,
+        "w": 12,
         "x": 0,
         "y": 8
       },
-      "hiddenSeries": false,
       "id": 37,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
       "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
           "datasource": "$source",
@@ -564,277 +660,112 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Priority: {{priority}}",
+          "legendFormat": "{{priority}}",
           "range": true,
           "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Concurrency Usage / Priority",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [
-        {
-          "id": "convertFieldType",
-          "options": {}
-        }
-      ],
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:703",
-          "format": "short",
-          "label": "",
-          "logBase": 1,
-          "min": "0",
-          "show": true
         },
         {
-          "$$hashKey": "object:704",
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 6,
-        "y": 8
-      },
-      "hiddenSeries": false,
-      "id": 38,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": "$source",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$source"
+          },
           "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(http_requests_queue_items_total{job=\"$application\", instance=~\"$instance\"}) by (job,priority)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Priority: {{priority}}",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Queue Usage / Priority",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": "",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 12,
-        "y": 8
-      },
-      "hiddenSeries": false,
-      "id": 31,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": "$source",
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(rate(http_requests_task_processing_time_seconds_count{job=\"$application\", instance=~\"$instance\"}[$__rate_interval])) by (method, priority)",
-          "format": "time_series",
+          "expr": "sum(http_requests_concurrency_limit_total{job=\"$application\", instance=~\"$instance\"}) by (job)",
+          "hide": false,
           "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{method}} {{priority}}",
+          "legendFormat": "limit",
+          "range": true,
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Task Execution / Second (Success)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
+      "title": "Concurrency Usage / Priority",
       "transformations": [
         {
           "id": "convertFieldType",
           "options": {}
         }
       ],
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "reqps",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 9,
-        "w": 6,
-        "x": 18,
+        "w": 12,
+        "x": 12,
         "y": 8
       },
-      "hiddenSeries": false,
       "id": 58,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
       "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
           "datasource": "$source",
@@ -849,419 +780,22 @@
           "refId": "B"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
       "title": "Concurrency Usage / Instance",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percentunit",
-          "label": "",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 0,
-        "y": 17
-      },
-      "hiddenSeries": false,
-      "id": 57,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": "$source",
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(http_requests_concurrency_limit_total{job=\"$application\", instance=~\"$instance\"}) by (job)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Limit",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "uid": "$source"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(http_requests_concurrency_items_total{job=\"$application\", instance=~\"$instance\"}) by (job)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Usage",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Concurrency Usage Total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": "",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 6,
-        "y": 17
-      },
-      "hiddenSeries": false,
-      "id": 30,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": "$source",
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(http_requests_queue_limit_total{job=\"$application\", instance=~\"$instance\"}) by (job)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Limit",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "uid": "$source"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(http_requests_queue_items_total{job=\"$application\", instance=~\"$instance\"}) by (job)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Usage",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Queue Usage Total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": "",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 12,
-        "y": 17
-      },
-      "hiddenSeries": false,
-      "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": "$source",
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(rate(http_requests_rejected_total{job=\"$application\", instance=~\"$instance\"}[$__rate_interval])) by (priority, method)",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{method}} - {{priority}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Rejection Rate / Priority",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transformations": [
         {
           "id": "convertFieldType",
-          "options": {}
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "Value"
+              }
+            ],
+            "fields": {}
+          }
         }
       ],
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "reqps",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 18,
-        "y": 17
-      },
-      "hiddenSeries": false,
-      "id": 32,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": "$source",
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(rate(process_cpu_seconds_total{job=\"$application\", instance=~\"$instance\"}[30s]) * 100) by (instance)",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "CPU",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "type": "timeseries"
     },
     {
       "collapsed": false,
@@ -1269,365 +803,254 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 17
       },
-      "id": 42,
+      "id": 64,
       "panels": [],
-      "title": "Latencies",
+      "title": "Queue",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$source",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$source"
+      },
       "fieldConfig": {
         "defaults": {
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 4,
-        "x": 0,
-        "y": 27
-      },
-      "hiddenSeries": false,
-      "id": 62,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "hideEmpty": false,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": "$source",
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "histogram_quantile(0.5, sum(rate(http_requests_task_processing_time_seconds_bucket{job=\"$application\", instance=~\"$instance\"}[$__rate_interval])) by (le, priority))",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{method}} {{priority}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Task Execution Time - P50",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "destinationType": "number",
-                "targetField": "Value"
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
-            ],
-            "fields": {}
-          }
-        }
-      ],
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "logBase": 1,
-          "min": "0",
-          "show": true
+            ]
+          },
+          "unit": "short"
         },
-        {
-          "format": "short",
-          "label": "",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "limit"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    5,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "opacity"
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 9,
-        "w": 4,
-        "x": 4,
-        "y": 27
+        "w": 12,
+        "x": 0,
+        "y": 18
       },
-      "hiddenSeries": false,
-      "id": 40,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
+      "id": 38,
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
       "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
           "datasource": "$source",
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.90, sum(rate(http_requests_task_processing_time_seconds_bucket{job=\"$application\", instance=~\"$instance\"}[$__rate_interval])) by (le, priority))",
+          "expr": "sum(http_requests_queue_items_total{job=\"$application\", instance=~\"$instance\"}) by (job, priority)",
           "format": "time_series",
-          "instant": false,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{priority}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Task Execution Time - P90",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Value"
-              }
-            ],
-            "fields": {}
-          }
-        }
-      ],
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "logBase": 1,
-          "min": "0",
-          "show": true
+          "range": true,
+          "refId": "B"
         },
         {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 4,
-        "x": 8,
-        "y": 27
-      },
-      "hiddenSeries": false,
-      "id": 45,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": "$source",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$source"
+          },
           "editorMode": "code",
-          "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(http_requests_task_processing_time_seconds_bucket{job=\"$application\", instance=~\"$instance\"}[$__rate_interval])) by (le, priority))",
-          "format": "time_series",
+          "expr": "sum(http_requests_queue_limit_total{job=\"$application\", instance=~\"$instance\"}) by (job)",
+          "hide": false,
           "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{method}} {{priority}}",
+          "legendFormat": "limit",
+          "range": true,
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Task Execution Time - P99",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
+      "title": "Queue Usage / Priority",
       "transformations": [
         {
           "id": "convertFieldType",
           "options": {}
         }
       ],
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 9,
         "w": 4,
         "x": 12,
-        "y": 27
+        "y": 18
       },
-      "hiddenSeries": false,
       "id": 35,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
       "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
           "datasource": {
@@ -1642,87 +1065,114 @@
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
       "title": "Queue Time P50",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transformations": [
         {
           "id": "convertFieldType",
-          "options": {}
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "critical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": "noncritical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": "normal"
+              }
+            ],
+            "fields": {}
+          }
         }
       ],
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 9,
         "w": 4,
         "x": 16,
-        "y": 27
+        "y": 18
       },
-      "hiddenSeries": false,
       "id": 63,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
       "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
           "datasource": {
@@ -1737,86 +1187,114 @@
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
       "title": "Queue Time P90",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transformations": [
         {
           "id": "convertFieldType",
-          "options": {}
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "critical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": "noncritical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": "normal"
+              }
+            ],
+            "fields": {}
+          }
         }
       ],
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": "$source",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 9,
         "w": 4,
         "x": 20,
-        "y": 27
+        "y": 18
       },
-      "hiddenSeries": false,
       "id": 39,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null as zero",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
       "pluginVersion": "9.3.6",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
           "datasource": {
@@ -1831,47 +1309,738 @@
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
       "title": "Queue Time P99",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "Priority critical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": "Priority noncritical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": "Priority normal"
+              }
+            ],
+            "fields": {}
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
       },
+      "id": 42,
+      "panels": [],
+      "title": "Execution",
+      "type": "row"
+    },
+    {
+      "datasource": "$source",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 28
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": "$source",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(http_requests_task_processing_time_seconds_count{job=\"$application\", instance=~\"$instance\"}[$__rate_interval])) by (method, priority)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{method}} {{priority}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Task Execution / Second (Success)",
       "transformations": [
         {
           "id": "convertFieldType",
           "options": {}
         }
       ],
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "logBase": 1,
-          "min": "0",
-          "show": true
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$source",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 28
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
         {
-          "format": "short",
-          "logBase": 1,
-          "show": true
+          "datasource": "$source",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(http_requests_rejected_total{job=\"$application\", instance=~\"$instance\"}[$__rate_interval])) by (priority, method)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{method}} - {{priority}}",
+          "refId": "A"
         }
       ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "Rejection Rate / Priority",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {}
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$source",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 4,
+        "x": 12,
+        "y": 28
+      },
+      "id": 62,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": "$source",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.5, sum(rate(http_requests_task_processing_time_seconds_bucket{job=\"$application\", instance=~\"$instance\"}[$__rate_interval])) by (le, priority))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{method}} {{priority}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Task Execution Time - P50",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": " critical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": " noncritical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": " normal"
+              }
+            ],
+            "fields": {}
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$source",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 4,
+        "x": 16,
+        "y": 28
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": "$source",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.90, sum(rate(http_requests_task_processing_time_seconds_bucket{job=\"$application\", instance=~\"$instance\"}[$__rate_interval])) by (le, priority))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{priority}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Task Execution Time - P90",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "critical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": "noncritical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": "normal"
+              }
+            ],
+            "fields": {}
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$source",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 4,
+        "x": 20,
+        "y": 28
+      },
+      "id": 45,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": "$source",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(http_requests_task_processing_time_seconds_bucket{job=\"$application\", instance=~\"$instance\"}[$__rate_interval])) by (le, priority))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{method}} {{priority}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Task Execution Time - P99",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": " critical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": " noncritical"
+              },
+              {
+                "destinationType": "number",
+                "targetField": " normal"
+              }
+            ],
+            "fields": {}
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 65,
+      "panels": [],
+      "title": "Resources",
+      "type": "row"
+    },
+    {
+      "datasource": "$source",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 38
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": "$source",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(process_cpu_seconds_total{job=\"$application\", instance=~\"$instance\"}[30s]) * 100) by (instance)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "Value"
+              }
+            ],
+            "fields": {}
+          }
+        }
+      ],
+      "type": "timeseries"
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 37,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [
     "kubernetes"
   ],
@@ -1880,8 +2049,8 @@
       {
         "current": {
           "selected": false,
-          "text": "LoadSheddingMetrics",
-          "value": "LoadSheddingMetrics"
+          "text": "",
+          "value": ""
         },
         "hide": 0,
         "includeAll": false,
@@ -1901,7 +2070,9 @@
           "text": "",
           "value": ""
         },
-        "datasource": "$source",
+        "datasource": {
+          "uid": "$source"
+        },
         "definition": "label_values(http_requests_concurrency_limit_total,job)",
         "hide": 0,
         "includeAll": false,
@@ -1931,15 +2102,17 @@
             "$__all"
           ]
         },
-        "datasource": "$source",
-        "definition": "label_values(http_requests_concurrency_limit_total,instance)",
+        "datasource": {
+          "uid": "$source"
+        },
+        "definition": "label_values(http_requests_concurrency_limit_total{job=\"$application\"},instance)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(http_requests_concurrency_limit_total,instance)",
+          "query": "label_values(http_requests_concurrency_limit_total{job=\"$application\"},instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1954,7 +2127,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {
@@ -1982,6 +2155,6 @@
   "timezone": "utc",
   "title": "http_loadshedding",
   "uid": "http_loadshedding",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/src/Farfetch.LoadShedding/Events/Args/ItemDequeuedEventArgs.cs
+++ b/src/Farfetch.LoadShedding/Events/Args/ItemDequeuedEventArgs.cs
@@ -6,29 +6,17 @@ namespace Farfetch.LoadShedding.Events.Args
     /// <summary>
     /// Event args for the task dequeued event.
     /// </summary>
-    public class ItemDequeuedEventArgs : ItemEventArgs
+    public class ItemDequeuedEventArgs : TaskQueueEventArgs
     {
-        internal ItemDequeuedEventArgs(Priority priority, TimeSpan queueTime, int queueLimit, int queueCount)
-            : base(priority)
+        internal ItemDequeuedEventArgs(Priority priority, TimeSpan queueTime, IReadOnlyCounter queueCounter)
+            : base(priority, queueCounter)
         {
             this.QueueTime = queueTime;
-            this.QueueLimit = queueLimit;
-            this.QueueCount = queueCount;
         }
 
         /// <summary>
         /// Gets the time waiting in the queue.
         /// </summary>
         public TimeSpan QueueTime { get; }
-
-        /// <summary>
-        /// Gets the maximum number of items in the queue.
-        /// </summary>
-        public int QueueLimit { get; }
-
-        /// <summary>
-        /// Gets the current number of items in the queue.
-        /// </summary>
-        public int QueueCount { get; }
     }
 }

--- a/src/Farfetch.LoadShedding/Events/Args/ItemEnqueuedEventArgs.cs
+++ b/src/Farfetch.LoadShedding/Events/Args/ItemEnqueuedEventArgs.cs
@@ -5,23 +5,11 @@ namespace Farfetch.LoadShedding.Events.Args
     /// <summary>
     /// Event args for the task enqueued event.
     /// </summary>
-    public class ItemEnqueuedEventArgs : ItemEventArgs
+    public class ItemEnqueuedEventArgs : TaskQueueEventArgs
     {
-        internal ItemEnqueuedEventArgs(Priority priority, int queueLimit, int queueCount)
-            : base(priority)
+        internal ItemEnqueuedEventArgs(Priority priority, IReadOnlyCounter queueCounter)
+            : base(priority, queueCounter)
         {
-            this.QueueLimit = queueLimit;
-            this.QueueCount = queueCount;
         }
-
-        /// <summary>
-        /// Gets the maximum number of items in the queue.
-        /// </summary>
-        public int QueueLimit { get; }
-
-        /// <summary>
-        /// Gets the current number of items in the queue.
-        /// </summary>
-        public int QueueCount { get; }
     }
 }

--- a/src/Farfetch.LoadShedding/Events/Args/ItemProcessedEventArgs.cs
+++ b/src/Farfetch.LoadShedding/Events/Args/ItemProcessedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Farfetch.LoadShedding.Tasks;
 
 namespace Farfetch.LoadShedding.Events.Args
@@ -6,29 +6,17 @@ namespace Farfetch.LoadShedding.Events.Args
     /// <summary>
     /// Event args for task processed event.
     /// </summary>
-    public class ItemProcessedEventArgs : ItemEventArgs
+    public class ItemProcessedEventArgs : TaskItemEventArgs
     {
-        internal ItemProcessedEventArgs(Priority priority, TimeSpan processingTime, int concurrencyLimit, int concurrencyCount)
-            : base(priority)
+        internal ItemProcessedEventArgs(Priority priority, TimeSpan processingTime, IReadOnlyCounter concurrencyCounter)
+            : base(priority, concurrencyCounter)
         {
             this.ProcessingTime = processingTime;
-            this.ConcurrencyLimit = concurrencyLimit;
-            this.ConcurrencyCount = concurrencyCount;
         }
 
         /// <summary>
         /// Gets time spent to process the task.
         /// </summary>
         public TimeSpan ProcessingTime { get; }
-
-        /// <summary>
-        /// Gets the current concurrency limit.
-        /// </summary>
-        public int ConcurrencyLimit { get; }
-
-        /// <summary>
-        /// Gets the current concurrency items count.
-        /// </summary>
-        public int ConcurrencyCount { get; }
     }
 }

--- a/src/Farfetch.LoadShedding/Events/Args/ItemProcessingEventArgs.cs
+++ b/src/Farfetch.LoadShedding/Events/Args/ItemProcessingEventArgs.cs
@@ -1,27 +1,15 @@
-﻿using Farfetch.LoadShedding.Tasks;
+using Farfetch.LoadShedding.Tasks;
 
 namespace Farfetch.LoadShedding.Events.Args
 {
     /// <summary>
-    /// Event args for task procssing event.
+    /// Event args for task processing event.
     /// </summary>
-    public class ItemProcessingEventArgs : ItemEventArgs
+    public class ItemProcessingEventArgs : TaskItemEventArgs
     {
-        internal ItemProcessingEventArgs(Priority priority, int concurrencyLimit, int concurrencyCount)
-            : base(priority)
+        internal ItemProcessingEventArgs(Priority priority, IReadOnlyCounter concurrencyCounter)
+            : base(priority, concurrencyCounter)
         {
-            this.ConcurrencyLimit = concurrencyLimit;
-            this.ConcurrencyCount = concurrencyCount;
         }
-
-        /// <summary>
-        /// Gets the current concurrency limit.
-        /// </summary>
-        public int ConcurrencyLimit { get; }
-
-        /// <summary>
-        /// Gets the current concurrency items count.
-        /// </summary>
-        public int ConcurrencyCount { get; }
     }
 }

--- a/src/Farfetch.LoadShedding/Events/Args/TaskItemEventArgs.cs
+++ b/src/Farfetch.LoadShedding/Events/Args/TaskItemEventArgs.cs
@@ -1,0 +1,28 @@
+using Farfetch.LoadShedding.Tasks;
+
+namespace Farfetch.LoadShedding.Events.Args
+{
+    /// <summary>
+    /// Event args for task item event.
+    /// </summary>
+    public class TaskItemEventArgs : ItemEventArgs
+    {
+        private readonly IReadOnlyCounter _concurrencyCounter;
+
+        internal TaskItemEventArgs(Priority priority, IReadOnlyCounter concurrencyCounter)
+            : base(priority)
+        {
+            _concurrencyCounter = concurrencyCounter;
+        }
+
+        /// <summary>
+        /// Gets the current concurrency limit.
+        /// </summary>
+        public int ConcurrencyLimit => _concurrencyCounter.Limit;
+
+        /// <summary>
+        /// Gets the current concurrency items count.
+        /// </summary>
+        public int ConcurrencyCount => _concurrencyCounter.Count;
+    }
+}

--- a/src/Farfetch.LoadShedding/Events/Args/TaskQueueEventArgs.cs
+++ b/src/Farfetch.LoadShedding/Events/Args/TaskQueueEventArgs.cs
@@ -1,0 +1,28 @@
+using Farfetch.LoadShedding.Tasks;
+
+namespace Farfetch.LoadShedding.Events.Args
+{
+    /// <summary>
+    /// Event args for the task queue event.
+    /// </summary>
+    public class TaskQueueEventArgs : ItemEventArgs
+    {
+        private readonly IReadOnlyCounter _queueCounter;
+
+        internal TaskQueueEventArgs(Priority priority, IReadOnlyCounter queueCounter)
+            : base(priority)
+        {
+            this._queueCounter = queueCounter;
+        }
+
+        /// <summary>
+        /// Gets the maximum number of items in the queue.
+        /// </summary>
+        public int QueueLimit => _queueCounter.Limit;
+
+        /// <summary>
+        /// Gets the current number of items in the queue.
+        /// </summary>
+        public int QueueCount => _queueCounter.Count;
+    }
+}

--- a/src/Farfetch.LoadShedding/Tasks/ConcurrentCounter.cs
+++ b/src/Farfetch.LoadShedding/Tasks/ConcurrentCounter.cs
@@ -1,8 +1,8 @@
 namespace Farfetch.LoadShedding.Tasks
 {
-    internal class ConcurrentCounter
+    internal class ConcurrentCounter : IReadOnlyCounter
     {
-        private readonly object _locker = new object();
+        private readonly object _locker = new();
 
         private int _count = 0;
 

--- a/src/Farfetch.LoadShedding/Tasks/ConcurrentCounter.cs
+++ b/src/Farfetch.LoadShedding/Tasks/ConcurrentCounter.cs
@@ -1,4 +1,4 @@
-﻿namespace Farfetch.LoadShedding.Tasks
+namespace Farfetch.LoadShedding.Tasks
 {
     internal class ConcurrentCounter
     {
@@ -64,10 +64,7 @@
         {
             lock (this._locker)
             {
-                if (this._count > 0)
-                {
-                    this._count--;
-                }
+                this._count--;
 
                 return this._count;
             }

--- a/src/Farfetch.LoadShedding/Tasks/IReadOnlyCounter.cs
+++ b/src/Farfetch.LoadShedding/Tasks/IReadOnlyCounter.cs
@@ -1,0 +1,9 @@
+namespace Farfetch.LoadShedding.Tasks
+{
+    internal interface IReadOnlyCounter
+    {
+        int Count { get; }
+
+        int Limit { get; }
+    }
+}

--- a/src/Farfetch.LoadShedding/Tasks/Priority.cs
+++ b/src/Farfetch.LoadShedding/Tasks/Priority.cs
@@ -6,17 +6,17 @@ namespace Farfetch.LoadShedding.Tasks
     public enum Priority
     {
         /// <summary>
-        /// Priority as critical.
+        /// Priority as Critical.
         /// </summary>
         Critical = 0,
 
         /// <summary>
-        /// Priority as normal.
+        /// Priority as Normal.
         /// </summary>
         Normal = 1,
 
         /// <summary>
-        /// Priority as critical.
+        /// Priority as Non Critical.
         /// </summary>
         NonCritical = 2,
     }

--- a/src/Farfetch.LoadShedding/Tasks/TaskManager.cs
+++ b/src/Farfetch.LoadShedding/Tasks/TaskManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Farfetch.LoadShedding.Constants;
@@ -12,7 +12,7 @@ namespace Farfetch.LoadShedding.Tasks
     {
         private readonly TaskQueue _taskQueue;
 
-        private readonly ConcurrentCounter _counter = new ConcurrentCounter();
+        private readonly ConcurrentCounter _counter = new();
 
         private readonly int _queueTimeout;
         private readonly ILoadSheddingEvents _events;
@@ -30,8 +30,8 @@ namespace Farfetch.LoadShedding.Tasks
 
             this._taskQueue = new TaskQueue(maxQueueSize)
             {
-                OnItemEnqueued = (count, item) => this.NotifyItemEnqueued(count, item),
-                OnItemDequeued = (count, item) => this.NotifyItemDequeued(count, item),
+                OnItemEnqueued = this.NotifyItemEnqueued,
+                OnItemDequeued = this.NotifyItemDequeued,
             };
 
             this._events?.ConcurrencyLimitChanged?.Raise(new LimitChangedEventArgs(this._counter.Limit));
@@ -86,11 +86,11 @@ namespace Farfetch.LoadShedding.Tasks
         {
             var item = this.CreateTask(priority);
 
-            if (this._counter.TryIncrement(out var currentCount))
+            if (this._counter.TryIncrement(out var _))
             {
                 item.Process();
 
-                this.NotifyItemProcessing(item, currentCount);
+                this.NotifyItemProcessing(item);
 
                 return item;
             }
@@ -124,7 +124,8 @@ namespace Farfetch.LoadShedding.Tasks
                     break;
             }
 
-            this.NotifyItemProcessing(item, this._counter.Increment());
+            this._counter.Increment();
+            this.NotifyItemProcessing(item);
 
             return item;
         }
@@ -136,10 +137,9 @@ namespace Farfetch.LoadShedding.Tasks
             item.OnCompleted = () =>
             {
                 var count = this._counter.Decrement();
-
                 var processNext = count < this._counter.Limit;
 
-                this.NotifyItemProcessed(item, count);
+                this.NotifyItemProcessed(item);
 
                 if (processNext)
                 {
@@ -155,32 +155,28 @@ namespace Farfetch.LoadShedding.Tasks
                 item.Priority,
                 reason));
 
-        private void NotifyItemProcessed(TaskItem item, int count)
+        private void NotifyItemProcessed(TaskItem item)
             => this._events?.ItemProcessed?.Raise(new ItemProcessedEventArgs(
                 item.Priority,
                 item.ProcessingTime,
-                this.ConcurrencyLimit,
-                count));
+                this._counter));
 
-        private void NotifyItemProcessing(TaskItem item, int count)
+        private void NotifyItemProcessing(TaskItem item)
             => this._events?.ItemProcessing?.Raise(new ItemProcessingEventArgs(
                 item.Priority,
-                this.ConcurrencyLimit,
-                count));
+                this._counter));
 
         private void NotifyConcurrencyLimitChanged()
             => this._events?.ConcurrencyLimitChanged?.Raise(new LimitChangedEventArgs(this._counter.Limit));
 
-        private void NotifyItemDequeued(int count, TaskItem item) => this._events?.ItemDequeued?.Raise(new ItemDequeuedEventArgs(
+        private void NotifyItemDequeued(TaskItem item) => this._events?.ItemDequeued?.Raise(new ItemDequeuedEventArgs(
              item.Priority,
              item.WaitingTime,
-             this._taskQueue.Limit,
-             count));
+             this._taskQueue));
 
-        private void NotifyItemEnqueued(int count, TaskItem item) => this._events?.ItemEnqueued?.Raise(new ItemEnqueuedEventArgs(
+        private void NotifyItemEnqueued(TaskItem item) => this._events?.ItemEnqueued?.Raise(new ItemEnqueuedEventArgs(
             item.Priority,
-            this._taskQueue.Limit,
-            count));
+            this._taskQueue));
 
         private void ProcessPendingTasks()
         {

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,7 +2,6 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../src'))" />
 
     <ItemGroup>
-        <Compile Include="$(MSBuildProjectDirectory)/../Traits.cs" Link="Properties/Traits.cs"/>
-		<AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
+        <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
     </ItemGroup>
 </Project>

--- a/tests/benchmark/Farfetch.LoadShedding.BenchmarkTests/Farfetch.LoadShedding.BenchmarkTests.csproj
+++ b/tests/benchmark/Farfetch.LoadShedding.BenchmarkTests/Farfetch.LoadShedding.BenchmarkTests.csproj
@@ -18,8 +18,4 @@
     <ProjectReference Include="..\..\..\src\Farfetch.LoadShedding\Farfetch.LoadShedding.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="$(MSBuildProjectDirectory)/../Traits.cs" />
-  </ItemGroup>
-
 </Project>

--- a/tests/benchmark/Farfetch.LoadShedding.BenchmarkTests/TaskQueueBenchmarks.cs
+++ b/tests/benchmark/Farfetch.LoadShedding.BenchmarkTests/TaskQueueBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using Farfetch.LoadShedding.Tasks;
 
@@ -13,11 +13,11 @@ namespace Farfetch.LoadShedding.BenchmarkTests
     [RankColumn]
     public class TaskQueueBenchmarks
     {
-        private readonly TaskQueue _queue = new TaskQueue(int.MaxValue);
+        private readonly TaskQueue _queue = new(int.MaxValue);
 
-        private readonly TaskQueue _emptyQueue = new TaskQueue(int.MaxValue);
+        private readonly TaskQueue _emptyQueue = new(int.MaxValue);
 
-        private readonly TaskQueue _limitedQueue = new TaskQueue(1000);
+        private readonly TaskQueue _limitedQueue = new(1000);
 
         [IterationSetup]
         public void Initialize()
@@ -38,7 +38,7 @@ namespace Farfetch.LoadShedding.BenchmarkTests
         }
 
         [Benchmark]
-        public void TaskQueueWith1000Items_EnqueueFixedPriority() => this._queue.Enqueue(new TaskItem(0));
+        public void TaskQueueWith1000Items_EnqueueFixedPriority() => this._queue.Enqueue(new TaskItem(Priority.Critical));
 
         [Benchmark]
         public void TaskQueueEmpty_EnqueueRandomPriority() => this._emptyQueue.Enqueue(GetTaskRandomPriority());
@@ -50,7 +50,7 @@ namespace Farfetch.LoadShedding.BenchmarkTests
         public void TaskQueueWith1000Items_Dequeue() => this._queue.Dequeue();
 
         [Benchmark]
-        public void TaskQueue_EnqueueNewItem_LimitReached() => this._limitedQueue.Enqueue(new TaskItem(0));
+        public void TaskQueue_EnqueueNewItem_LimitReached() => this._limitedQueue.Enqueue(new TaskItem(Priority.Critical));
 
         private static TaskItem GetTaskRandomPriority()
         {

--- a/tests/integration-tests/Directory.Build.props
+++ b/tests/integration-tests/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+
+    <ItemGroup>
+        <Compile Include="$(MSBuildProjectDirectory)/../Traits.cs" Link="Properties/Traits.cs"/>
+    </ItemGroup>
+</Project>

--- a/tests/performance-tests/Farfetch.LoadShedding.PerformanceTests/Farfetch.LoadShedding.PerformanceTests.csproj
+++ b/tests/performance-tests/Farfetch.LoadShedding.PerformanceTests/Farfetch.LoadShedding.PerformanceTests.csproj
@@ -17,8 +17,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="$(MSBuildProjectDirectory)/../Traits.cs" />
-  </ItemGroup>
-
 </Project>

--- a/tests/unit-tests/Directory.Build.props
+++ b/tests/unit-tests/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+
+    <ItemGroup>
+        <Compile Include="$(MSBuildProjectDirectory)/../Traits.cs" Link="Properties/Traits.cs"/>
+        <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
+    </ItemGroup>
+</Project>

--- a/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskItemTests.cs
+++ b/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskItemTests.cs
@@ -9,7 +9,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
         public async Task WaitAsync_Process_ReturnsProcessingStatus()
         {
             // Arrange
-            var taskItem = new TaskItem(0);
+            var taskItem = new TaskItem(Priority.Critical);
 
             var waitingTask = taskItem.WaitAsync(10000, CancellationToken.None);
 
@@ -26,7 +26,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
         public async Task WaitAsync_TimeoutReached_ReturnsCanceledStatus()
         {
             // Arrange
-            var taskItem = new TaskItem(0);
+            var taskItem = new TaskItem(Priority.Critical);
 
             var waitingTask = taskItem.WaitAsync(1, CancellationToken.None);
 
@@ -43,7 +43,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
         public async Task WaitAsync_CancelledToken_ReturnsCanceledStatus()
         {
             // Arrange
-            var taskItem = new TaskItem(0);
+            var taskItem = new TaskItem(Priority.Critical);
 
             using var source = new CancellationTokenSource();
 
@@ -62,7 +62,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
         public async Task WaitAsync_Reject_ReturnsProcessingStatus()
         {
             // Arrange
-            var taskItem = new TaskItem(0);
+            var taskItem = new TaskItem(Priority.Critical);
 
             var waitingTask = taskItem.WaitAsync(10000, CancellationToken.None);
 

--- a/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskManagerTests.cs
+++ b/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskManagerTests.cs
@@ -243,13 +243,12 @@ namespace Farfetch.LoadShedding.Tests.Tasks
             var processingItems = new List<ItemProcessingEventArgs>();
 
             var events = new LoadSheddingEvents();
-
             events.ItemProcessed.Subscribe(args => processedItems.Add(args));
             events.ItemProcessing.Subscribe(args => processingItems.Add(args));
 
             var target = new TaskManager(10, 10, Timeout.Infinite, events);
 
-            var item = await target.AcquireAsync(0);
+            var item = await target.AcquireAsync(Priority.Critical);
 
             // Act
             item.Complete();
@@ -257,7 +256,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
             // Assert
             Assert.Single(processingItems);
             Assert.Equal(item.Priority, processingItems.First().Priority);
-            Assert.Equal(1, processingItems.First().ConcurrencyCount);
+            Assert.Equal(0, processingItems.First().ConcurrencyCount);
             Assert.Equal(10, processingItems.First().ConcurrencyLimit);
 
             Assert.Single(processedItems);

--- a/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskQueueTests.cs
+++ b/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskQueueTests.cs
@@ -19,7 +19,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
         public void Enqueue_QueueLimitNotReached_AddToQueue()
         {
             // Arrange
-            var task = new TaskItem(0);
+            var task = new TaskItem(Priority.Critical);
 
             // Act
             this._target.Enqueue(task);
@@ -35,8 +35,8 @@ namespace Farfetch.LoadShedding.Tests.Tasks
             // Arrange
             this._target.Limit = 1;
 
-            var firstTask = new TaskItem(0);
-            var lastTask = new TaskItem(0);
+            var firstTask = new TaskItem(Priority.Critical);
+            var lastTask = new TaskItem(Priority.Critical);
 
             this._target.Enqueue(firstTask);
 
@@ -57,7 +57,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
             var lowPriorityTask = new TaskItem(Priority.NonCritical);
             this._target.Enqueue(lowPriorityTask);
 
-            var highPriorityTask = new TaskItem(0);
+            var highPriorityTask = new TaskItem(Priority.Critical);
 
             // Act
             this._target.Enqueue(highPriorityTask);


### PR DESCRIPTION
# Description

* Feature: Update the Grafana dashboard
  * Show queue time zero when we don't have anything in queue
  * Show concurrency and queue counters and limits on the same widget
* Fix: Queue was decreased twice when items were rejected
* Fix: Queue was not decreased if events are not defined
* Fix: Report to the events (Processing and Queue) the current counter values (count and limit) instead of those at the event time

Fixes #16 

## How Has This Been Tested?

Run the load tests and at the end of the tests, the queue and concurrency gauge metrics should report the value zero.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
