### PR TITLE
feat: Inc and Dec gauge metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ sample:
 
 sample-clean:
 	@docker compose -f docker-compose.sample.yaml down
+
+benchmark:
+	dotnet run -c Release --project ./tests/benchmark/Farfetch.LoadShedding.BenchmarkTests/Farfetch.LoadShedding.BenchmarkTests.csproj

--- a/src/Farfetch.LoadShedding.AspNetCore/Resolvers/HttpHeaderPriorityResolver.cs
+++ b/src/Farfetch.LoadShedding.AspNetCore/Resolvers/HttpHeaderPriorityResolver.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Farfetch.LoadShedding.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -8,8 +7,6 @@ namespace Farfetch.LoadShedding.AspNetCore.Resolvers
     internal class HttpHeaderPriorityResolver : IPriorityResolver
     {
         internal const string DefaultPriorityHeaderName = "X-Priority";
-
-        private const string Separator = "-";
 
         private readonly string _headerName;
 
@@ -30,21 +27,7 @@ namespace Farfetch.LoadShedding.AspNetCore.Resolvers
                 return Task.FromResult(Priority.Normal);
             }
 
-            var normalizedValue = this.NormalizeHeaderValue(values);
-
-            if (!Enum.TryParse(normalizedValue, true, out Priority priority))
-            {
-                priority = Priority.Normal;
-            }
-
-            return Task.FromResult(priority);
-        }
-
-        private string NormalizeHeaderValue(string headerValue)
-        {
-            return headerValue
-                .Replace(Separator, string.Empty)
-                .ToLower();
+            return Task.FromResult(values.ToString().ParsePriority());
         }
     }
 }

--- a/src/Farfetch.LoadShedding.Prometheus/Metrics/HttpRequestsConcurrencyItemsGauge.cs
+++ b/src/Farfetch.LoadShedding.Prometheus/Metrics/HttpRequestsConcurrencyItemsGauge.cs
@@ -1,5 +1,4 @@
 using Prometheus;
-
 using PrometheusBase = Prometheus;
 
 namespace Farfetch.LoadShedding.Prometheus.Metrics
@@ -22,16 +21,27 @@ namespace Farfetch.LoadShedding.Prometheus.Metrics
         protected override string DefaultName => "http_requests_concurrency_items_total";
 
         /// <summary>
-        /// Sets the value of the gauge.
+        /// Increments the value of the gauge.
         /// </summary>
         /// <param name="method">The method.</param>
         /// <param name="priority">The priority.</param>
-        /// <param name="value">The value.</param>
-        public void Set(string method, string priority, double value)
+        public void Increment(string method, string priority)
         {
             this.Metric?
                 .WithLabels(method, priority)
-                .Set(value);
+                .Inc();
+        }
+
+        /// <summary>
+        /// Decrements the value of the gauge.
+        /// </summary>
+        /// <param name="method">The method.</param>
+        /// <param name="priority">The priority.</param>
+        public void Decrement(string method, string priority)
+        {
+            this.Metric?
+                .WithLabels(method, priority)
+                .Dec();
         }
 
         /// <inheritdoc/>
@@ -40,7 +50,7 @@ namespace Farfetch.LoadShedding.Prometheus.Metrics
             return PrometheusBase
                .Metrics
                .WithCustomRegistry(registry)
-               .CreateGauge(options.Name, Description, new PrometheusBase.GaugeConfiguration
+               .CreateGauge(options.Name, Description, new GaugeConfiguration
                {
                    LabelNames = new[] { MetricsConstants.MethodLabel, MetricsConstants.PriorityLabel },
                });

--- a/src/Farfetch.LoadShedding.Prometheus/Metrics/HttpRequestsQueueItemsGauge.cs
+++ b/src/Farfetch.LoadShedding.Prometheus/Metrics/HttpRequestsQueueItemsGauge.cs
@@ -1,5 +1,4 @@
 using Prometheus;
-
 using PrometheusBase = Prometheus;
 
 namespace Farfetch.LoadShedding.Prometheus.Metrics
@@ -22,16 +21,27 @@ namespace Farfetch.LoadShedding.Prometheus.Metrics
         protected override string DefaultName => "http_requests_queue_items_total";
 
         /// <summary>
-        /// Sets the value of the gauge.
+        /// Increments the value of the gauge.
         /// </summary>
         /// <param name="method">The method.</param>
         /// <param name="priority">The priority.</param>
-        /// <param name="value">The value.</param>
-        public void Set(string method, string priority, double value)
+        public void Increment(string method, string priority)
         {
             this.Metric?
                 .WithLabels(method, priority)
-                .Set(value);
+                .Inc();
+        }
+
+        /// <summary>
+        /// Decrements the value of the gauge.
+        /// </summary>
+        /// <param name="method">The method.</param>
+        /// <param name="priority">The priority.</param>
+        public void Decrement(string method, string priority)
+        {
+            this.Metric?
+                .WithLabels(method, priority)
+                .Dec();
         }
 
         /// <inheritdoc/>

--- a/src/Farfetch.LoadShedding/Tasks/ConcurrentCounter.cs
+++ b/src/Farfetch.LoadShedding/Tasks/ConcurrentCounter.cs
@@ -64,10 +64,7 @@ namespace Farfetch.LoadShedding.Tasks
         {
             lock (this._locker)
             {
-                if (this._count > 0)
-                {
-                    this._count--;
-                }
+                this._count--;
 
                 return this._count;
             }

--- a/src/Farfetch.LoadShedding/Tasks/PriorityExtensions.cs
+++ b/src/Farfetch.LoadShedding/Tasks/PriorityExtensions.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Farfetch.LoadShedding.Tasks
+{
+    /// <summary>
+    /// Extension methods of <see cref="Priority"/>
+    /// </summary>
+    public static class PriorityExtensions
+    {
+        /// <summary>
+        /// Parses a string value into a <see cref="Priority"/> enum.
+        /// The parser is case-insensetive and accepts hyphen. e.g. Normal, Non-Critival or CRITICAL.
+        /// </summary>
+        /// <param name="value">Priority string value to be parsed.</param>
+        /// <returns>The Priority parsed value. Returns Priority.Normal if the value is invalid.</returns>
+        public static Priority ParsePriority(this string value)
+        {
+            if (value is null)
+            {
+                return Priority.Normal;
+            }
+
+            var normalizedValue = value
+                .Replace("-", string.Empty)
+                .ToLowerInvariant();
+
+            if (Enum.TryParse(normalizedValue, true, out Priority priority))
+            {
+                return priority;
+            }
+
+            return Priority.Normal;
+        }
+
+        /// <summary>
+        /// Format a <see cref="Priority"/> enum to a string.
+        /// </summary>
+        /// <param name="priority">Priority value to be formatted.</param>
+        /// <returns>The Priority format string.</returns>
+        public static string FormatPriority(this Priority priority)
+        {
+            return priority.ToString().ToLowerInvariant();
+        }
+    }
+}

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,7 +2,6 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../src'))" />
 
     <ItemGroup>
-        <Compile Include="$(MSBuildProjectDirectory)/../Traits.cs" Link="Properties/Traits.cs"/>
-		<AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
+        <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
     </ItemGroup>
 </Project>

--- a/tests/benchmark/Farfetch.LoadShedding.BenchmarkTests/Farfetch.LoadShedding.BenchmarkTests.csproj
+++ b/tests/benchmark/Farfetch.LoadShedding.BenchmarkTests/Farfetch.LoadShedding.BenchmarkTests.csproj
@@ -18,8 +18,4 @@
     <ProjectReference Include="..\..\..\src\Farfetch.LoadShedding\Farfetch.LoadShedding.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="$(MSBuildProjectDirectory)/../Traits.cs" />
-  </ItemGroup>
-
 </Project>

--- a/tests/benchmark/Farfetch.LoadShedding.BenchmarkTests/TaskQueueBenchmarks.cs
+++ b/tests/benchmark/Farfetch.LoadShedding.BenchmarkTests/TaskQueueBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using Farfetch.LoadShedding.Tasks;
 
@@ -13,11 +13,11 @@ namespace Farfetch.LoadShedding.BenchmarkTests
     [RankColumn]
     public class TaskQueueBenchmarks
     {
-        private readonly TaskQueue _queue = new TaskQueue(int.MaxValue);
+        private readonly TaskQueue _queue = new(int.MaxValue);
 
-        private readonly TaskQueue _emptyQueue = new TaskQueue(int.MaxValue);
+        private readonly TaskQueue _emptyQueue = new(int.MaxValue);
 
-        private readonly TaskQueue _limitedQueue = new TaskQueue(1000);
+        private readonly TaskQueue _limitedQueue = new(1000);
 
         [IterationSetup]
         public void Initialize()
@@ -38,7 +38,7 @@ namespace Farfetch.LoadShedding.BenchmarkTests
         }
 
         [Benchmark]
-        public void TaskQueueWith1000Items_EnqueueFixedPriority() => this._queue.Enqueue(new TaskItem(0));
+        public void TaskQueueWith1000Items_EnqueueFixedPriority() => this._queue.Enqueue(new TaskItem(Priority.Critical));
 
         [Benchmark]
         public void TaskQueueEmpty_EnqueueRandomPriority() => this._emptyQueue.Enqueue(GetTaskRandomPriority());
@@ -50,7 +50,7 @@ namespace Farfetch.LoadShedding.BenchmarkTests
         public void TaskQueueWith1000Items_Dequeue() => this._queue.Dequeue();
 
         [Benchmark]
-        public void TaskQueue_EnqueueNewItem_LimitReached() => this._limitedQueue.Enqueue(new TaskItem(0));
+        public void TaskQueue_EnqueueNewItem_LimitReached() => this._limitedQueue.Enqueue(new TaskItem(Priority.Critical));
 
         private static TaskItem GetTaskRandomPriority()
         {

--- a/tests/integration-tests/Directory.Build.props
+++ b/tests/integration-tests/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+
+    <ItemGroup>
+        <Compile Include="$(MSBuildProjectDirectory)/../Traits.cs" Link="Properties/Traits.cs"/>
+    </ItemGroup>
+</Project>

--- a/tests/integration-tests/Farfetch.LoadShedding.IntegrationTests/Base/Controllers/WebApiTestController.cs
+++ b/tests/integration-tests/Farfetch.LoadShedding.IntegrationTests/Base/Controllers/WebApiTestController.cs
@@ -1,6 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Farfetch.LoadShedding.AspNetCore.Attributes;
 using Farfetch.LoadShedding.IntegrationTests.Base.Models;
+using Farfetch.LoadShedding.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Farfetch.LoadShedding.IntegrationTests.Base.Controllers
@@ -12,7 +13,7 @@ namespace Farfetch.LoadShedding.IntegrationTests.Base.Controllers
     {
         [HttpGet]
         [Route("people")]
-        [EndpointPriority(Tasks.Priority.Critical)]
+        [EndpointPriority(Priority.Critical)]
         public async Task<IActionResult> GetPeopleAsync()
         {
             await Task.Delay(500);
@@ -26,6 +27,14 @@ namespace Farfetch.LoadShedding.IntegrationTests.Base.Controllers
                     UserName = "john.doe",
                 },
             });
+        }
+
+        [HttpDelete]
+        [Route("people")]
+        [EndpointPriority(Priority.Critical)]
+        public Task DeletePeopleAsync()
+        {
+            return Task.Delay(500);
         }
     }
 }

--- a/tests/performance-tests/Farfetch.LoadShedding.PerformanceTests/Farfetch.LoadShedding.PerformanceTests.csproj
+++ b/tests/performance-tests/Farfetch.LoadShedding.PerformanceTests/Farfetch.LoadShedding.PerformanceTests.csproj
@@ -17,8 +17,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="$(MSBuildProjectDirectory)/../Traits.cs" />
-  </ItemGroup>
-
 </Project>

--- a/tests/unit-tests/Directory.Build.props
+++ b/tests/unit-tests/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+
+    <ItemGroup>
+        <Compile Include="$(MSBuildProjectDirectory)/../Traits.cs" Link="Properties/Traits.cs"/>
+        <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
+    </ItemGroup>
+</Project>

--- a/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/PriorityExtensionsTests.cs
+++ b/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/PriorityExtensionsTests.cs
@@ -1,0 +1,52 @@
+using Farfetch.LoadShedding.Tasks;
+using Xunit;
+
+namespace Farfetch.LoadShedding.Tests.Tasks
+{
+    public class PriorityExtensionsTests
+    {
+        [Theory]
+        [InlineData("Critical", Priority.Critical)]
+        [InlineData("critical", Priority.Critical)]
+        [InlineData("criti-cal", Priority.Critical)]
+        [InlineData("critical-", Priority.Critical)]
+        [InlineData("-critical", Priority.Critical)]
+        [InlineData("--critical", Priority.Critical)]
+        [InlineData("NORMAL", Priority.Normal)]
+        [InlineData("normal", Priority.Normal)]
+        [InlineData("nor-mal", Priority.Normal)]
+        [InlineData("nor--mal", Priority.Normal)]
+        [InlineData("normal-", Priority.Normal)]
+        [InlineData("-normal", Priority.Normal)]
+        [InlineData("noncritical", Priority.NonCritical)]
+        [InlineData("non-critical", Priority.NonCritical)]
+        [InlineData("NON-critical", Priority.NonCritical)]
+        [InlineData("noncritical-", Priority.NonCritical)]
+        [InlineData("noncritical--", Priority.NonCritical)]
+        [InlineData("-NONCRITICAL", Priority.NonCritical)]
+        [InlineData("", Priority.Normal)]
+        [InlineData(null, Priority.Normal)]
+        [InlineData("other", Priority.Normal)]
+        public void ParsePriority(string? value, Priority priority)
+        {
+            // Act
+            var result = PriorityExtensions.ParsePriority(value);
+
+            // Assert
+            Assert.Equal(priority, result);
+        }
+
+        [Theory]
+        [InlineData(Priority.Critical, "critical")]
+        [InlineData(Priority.Normal, "normal")]
+        [InlineData(Priority.NonCritical, "noncritical")]
+        public void FormatPriority(Priority priority, string value)
+        {
+            // Act
+            var result = PriorityExtensions.FormatPriority(priority);
+
+            // Assert
+            Assert.Equal(value, result);
+        }
+    }
+}

--- a/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskItemTests.cs
+++ b/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskItemTests.cs
@@ -9,7 +9,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
         public async Task WaitAsync_Process_ReturnsProcessingStatus()
         {
             // Arrange
-            var taskItem = new TaskItem(0);
+            var taskItem = new TaskItem(Priority.Critical);
 
             var waitingTask = taskItem.WaitAsync(10000, CancellationToken.None);
 
@@ -26,7 +26,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
         public async Task WaitAsync_TimeoutReached_ReturnsCanceledStatus()
         {
             // Arrange
-            var taskItem = new TaskItem(0);
+            var taskItem = new TaskItem(Priority.Critical);
 
             var waitingTask = taskItem.WaitAsync(1, CancellationToken.None);
 
@@ -43,7 +43,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
         public async Task WaitAsync_CancelledToken_ReturnsCanceledStatus()
         {
             // Arrange
-            var taskItem = new TaskItem(0);
+            var taskItem = new TaskItem(Priority.Critical);
 
             using var source = new CancellationTokenSource();
 
@@ -62,7 +62,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
         public async Task WaitAsync_Reject_ReturnsProcessingStatus()
         {
             // Arrange
-            var taskItem = new TaskItem(0);
+            var taskItem = new TaskItem(Priority.Critical);
 
             var waitingTask = taskItem.WaitAsync(10000, CancellationToken.None);
 

--- a/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskManagerTests.cs
+++ b/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskManagerTests.cs
@@ -33,11 +33,12 @@ namespace Farfetch.LoadShedding.Tests.Tasks
             // Arrange
             const int ExpectedTotalCount = 20, ExpectedQueueSize = 20;
 
-            var target = new TaskManager(10, 10);
-
             // Act
-            target.ConcurrencyLimit = ExpectedTotalCount;
-            target.QueueLimit = ExpectedQueueSize;
+            var target = new TaskManager(10, 10)
+            {
+                ConcurrencyLimit = ExpectedTotalCount,
+                QueueLimit = ExpectedQueueSize,
+            };
 
             // Assert
             Assert.Equal(ExpectedTotalCount, target.ConcurrencyLimit);
@@ -71,10 +72,11 @@ namespace Farfetch.LoadShedding.Tests.Tasks
 
             events.ConcurrencyLimitChanged.Subscribe(args => currentLimit = args.Limit);
 
-            var target = new TaskManager(10, 10, Timeout.Infinite, events);
-
             // Act
-            target.ConcurrencyLimit = expectedMaxCount;
+            var target = new TaskManager(10, 10, Timeout.Infinite, events)
+            {
+                ConcurrencyLimit = expectedMaxCount,
+            };
 
             // Assert
             Assert.Equal(expectedMaxCount, currentLimit);
@@ -243,13 +245,12 @@ namespace Farfetch.LoadShedding.Tests.Tasks
             var processingItems = new List<ItemProcessingEventArgs>();
 
             var events = new LoadSheddingEvents();
-
             events.ItemProcessed.Subscribe(args => processedItems.Add(args));
             events.ItemProcessing.Subscribe(args => processingItems.Add(args));
 
             var target = new TaskManager(10, 10, Timeout.Infinite, events);
 
-            var item = await target.AcquireAsync(0);
+            var item = await target.AcquireAsync(Priority.Critical);
 
             // Act
             item.Complete();

--- a/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskQueueTests.cs
+++ b/tests/unit-tests/Farfetch.LoadShedding.Tests/Tasks/TaskQueueTests.cs
@@ -19,7 +19,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
         public void Enqueue_QueueLimitNotReached_AddToQueue()
         {
             // Arrange
-            var task = new TaskItem(0);
+            var task = new TaskItem(Priority.Critical);
 
             // Act
             this._target.Enqueue(task);
@@ -35,8 +35,8 @@ namespace Farfetch.LoadShedding.Tests.Tasks
             // Arrange
             this._target.Limit = 1;
 
-            var firstTask = new TaskItem(0);
-            var lastTask = new TaskItem(0);
+            var firstTask = new TaskItem(Priority.Critical);
+            var lastTask = new TaskItem(Priority.Critical);
 
             this._target.Enqueue(firstTask);
 
@@ -57,7 +57,7 @@ namespace Farfetch.LoadShedding.Tests.Tasks
             var lowPriorityTask = new TaskItem(Priority.NonCritical);
             this._target.Enqueue(lowPriorityTask);
 
-            var highPriorityTask = new TaskItem(0);
+            var highPriorityTask = new TaskItem(Priority.Critical);
 
             // Act
             this._target.Enqueue(highPriorityTask);


### PR DESCRIPTION
# Description

The [Prometheus documentation](https://github.com/prometheus-net/prometheus-net/blob/master/README.md#gauges) suggests using the Inc and Dec method for a queue problem as we have here.

As I mentioned in #22, it is possible to replicate using only unit tests.

This commit changes the use of `gauge.Set` to `gauge.Inc` and `gauge.Dec` in the queue and concurrency events.

Fixes #22 

## How Has This Been Tested?

Run the integration tests.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
